### PR TITLE
Update Dockerfile to use /tmp/make_iso.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN sed -i 's/^MAGIC=.*$/MAGIC=""/' $ROOTFS/etc/rc.d/automount
 
 ADD opennebula-context $ROOTFS/etc/rc.d/opennebula-context
 
-RUN /make_iso.sh
+RUN /tmp/make_iso.sh
 CMD ["cat", "boot2docker.iso"]


### PR DESCRIPTION
boot2docker now uses /tmp/make_iso.sh, instead of /make_iso.sh